### PR TITLE
SettingsActivity: document ui_options label mapping for value-label row

### DIFF
--- a/docs/frameworks/setting-activity.md
+++ b/docs/frameworks/setting-activity.md
@@ -37,7 +37,7 @@ Each setting is defined as a dictionary with the following properties:
 
 ### Optional Properties
 - **`ui`** (string): UI type to use for editing. Options: `"textarea"` (default), `"radiobuttons"`, `"dropdown"`, `"activity"`
-- **`ui_options`** (list): Options for `radiobuttons` and `dropdown` UI types
+- **`ui_options`** (list): Options for `radiobuttons` and `dropdown` UI types. Each entry is a `(label, value)` tuple — the **label** appears on the radio button or dropdown row AND in the parent `SettingsActivity`'s value-label row beneath the title. The **value** is what gets stored in SharedPreferences. See [SettingsActivity → Display Labels for `ui_options`](settings-activity.md#display-labels-for-ui_options) for details.
 - **`placeholder`** (string): Placeholder text for textarea input
 - **`default_value`** (string): Default value to select or fill in
 - **`changed_callback`** (function): Callback function called when the setting value changes

--- a/docs/frameworks/settings-activity.md
+++ b/docs/frameworks/settings-activity.md
@@ -36,7 +36,7 @@ class MyApp(Activity):
 
 ### Optional Properties
 - **`ui`** (string): UI type for editing. Options: `"textarea"` (default), `"radiobuttons"`, `"dropdown"`, `"activity"`
-- **`ui_options`** (list): Options for `radiobuttons` and `dropdown` UI types
+- **`ui_options`** (list): Options for `radiobuttons` and `dropdown` UI types. Each entry is a `(label, value)` tuple — the **label** is shown in the picker AND in the row's value label below the title; the **value** is what gets stored in SharedPreferences. See [Display Labels for `ui_options`](#display-labels-for-ui_options) below.
 - **`placeholder`** (string): Placeholder text for textarea input
 - **`changed_callback`** (function): Callback function called when the setting value changes
 - **`should_show`** (function): Function to determine if this setting should be displayed in the list
@@ -106,6 +106,28 @@ Use a custom Activity class for advanced UI implementations.
     "activity_class": ColorPickerActivity
 }
 ```
+
+## Display Labels for `ui_options`
+
+For `radiobuttons` and `dropdown` settings, each entry in `ui_options` is a `(label, value)` tuple:
+
+```python
+"ui_options": [
+    ("Lightning Piggy", "lightningpiggy"),    # ← label  ← stored value
+    ("Lightning Penguin", "lightningpenguin"),
+    ("None", "none"),
+]
+```
+
+The settings-list row beneath each setting's title shows the **label** corresponding to the current stored value — not the raw value. So a row whose stored value is `"lightningpiggy"` displays "Lightning Piggy" below the title, matching what the user picked in the picker. This applies both on initial render and after a save.
+
+If the stored value isn't present in the current `ui_options` list (e.g. a stale pref from before the option set changed), the raw value is shown unchanged rather than collapsing to "(not set)" — so the user can still see and recover from a now-invalid value.
+
+Tips for choosing labels and values:
+
+- **Labels** should be human-readable with spaces, casing, and punctuation as you want them shown to the user ("Lightning Piggy", not "lightningpiggy").
+- **Values** should be machine-friendly identifiers — short, no spaces, stable across releases. They appear in SharedPreferences and in any export/import flows, so keep them URL-safe and ASCII when possible.
+- **Don't change values for existing options** without a migration. The label can change freely (it's a presentation concern); the value is the identity.
 
 ## Advanced Features
 


### PR DESCRIPTION
## Summary

Companion to [MicroPythonOS#137](https://github.com/MicroPythonOS/MicroPythonOS/pull/137) which makes `SettingsActivity` honour the `(label, value)` tuple in `ui_options` when rendering the row's value label.

Adds:

- A new "Display Labels for `ui_options`" section to `settings-activity.md` covering the (label, value) tuple format, the initial-render + post-save behaviour, the fall-through for stale stored values, and tips for choosing labels vs values.
- A clarifying inline note on the `ui_options` description in **both** `settings-activity.md` and `setting-activity.md` so callers know the label is shown in the parent list row (not just inside the picker).
- A cross-reference from `setting-activity.md` to the new section.

## Why

Before MPOS#137, a setting like:

```python
{"title": "Hero Image", "key": "hero_image", "ui": "radiobuttons",
 "ui_options": [("Lightning Piggy", "lightningpiggy"), ...]}
```

…displayed `"lightningpiggy"` (the raw value, no space) in the row beneath the title, even though the picker correctly showed `"Lightning Piggy"`. MPOS#137 fixes the framework; this doc PR explains the contract so framework users know to expect label-display (and what to do for stale values that no longer appear in `ui_options`).

## Test plan

- [x] Markdown renders cleanly
- [ ] Docs site preview: confirm the new section anchor + cross-reference from setting-activity.md resolve
- [ ] Once MicroPythonOS#137 merges, verify the documented behaviour matches the framework